### PR TITLE
fix landing page of user

### DIFF
--- a/static/js/onepage.js
+++ b/static/js/onepage.js
@@ -637,9 +637,9 @@ define(["jquery", "underscore", "backbone", "helper/util", "config/app-config", 
                     return;
                 } 
 
-                // redirect the user to any of the clusters
+                // redirect the user to one of the clusters
                 clusters = window.AMCGLOBALS.persistent.currentlyMonitoringCluster;
-                if (clusters !== null && clusters.length > 0) {
+                if (_.isArray(clusters) && clusters.length > 0) {
                     cluster = clusters[0];
                     window.location.hash = "dashboard/" + cluster.seed_node;
                     return;


### PR DESCRIPTION
when url is empty redirect the user to one of the existing clusters
instead of the multicluster view.

unchanged
--------------
- url is to a security enabled cluster, but user is not logged in -- show user, password login popup
- url is to a logged in or security disabled cluster -- show the dashboard 

changed
-----------
- url contains no cluster -- (earlier it was show multi cluster view) 
Change is now it takes you to get_current_monitoring_clusters[0]