### PR TITLE
fix tls for a connection only if configured

### DIFF
--- a/models/observer.go
+++ b/models/observer.go
@@ -60,8 +60,10 @@ func New(config *common.Config) *ObserverT {
 		if common.AMCIsEnterprise() {
 			cp.User = server.User
 			cp.Password = server.Password
-			if server.TLSName != "" {
-				host.TLSName = server.TLSName
+
+			tlsName := strings.TrimSpace(server.TLSName)
+			if len(tlsName) > 0 {
+				host.TLSName = tlsName
 
 				tc := &tls.Config{
 					Certificates:             config.ClientPool(),


### PR DESCRIPTION
tls credentials are added to a connection to a node on startup only if
the cluster has been configured with tls.