### PR TITLE
microsecond-histograms support and some minor bug fixes

### DIFF
--- a/amc.dev.conf
+++ b/amc.dev.conf
@@ -33,7 +33,7 @@ cluster_inactive_before_removal = 1800
 	#alias =
 
 	[amc.clusters.db2]
-	host = "vmu1604"
+	host = "172.17.0.3"
 	#tls_name = ""
 	port = 3000
 	#user = "admin"

--- a/controllers/enterprise.go
+++ b/controllers/enterprise.go
@@ -104,6 +104,7 @@ func transformLatency(latestLatency map[string]common.Stats) common.Stats {
 	for op, stats := range latestLatency {
 		buckets := stats["buckets"].([]string)
 		valBuckets := stats["valBuckets"].([]float64)
+		histUnit := stats["histUnit"]
 
 		totalOver1ms := 0.0
 		for _, v := range valBuckets {
@@ -149,6 +150,7 @@ func transformLatency(latestLatency map[string]common.Stats) common.Stats {
 			"timestamp":      timestamp,
 			"timestamp_unix": stats["timestamp_unix"],
 			"ops/sec":        tps,
+			"units":          histUnit,
 			"data":           data,
 		}
 	}
@@ -206,6 +208,7 @@ func getNodesLatencyHistory(c echo.Context) error {
 		res[node.Address()] = common.Stats{
 			"node_status":     node.Status(),
 			"node_build":      node.Build(),
+			"latency_units":   node.LatencyUnits(),
 			"latency_history": latencyHistory,
 			"address":         node.Address(),
 		}

--- a/models/node.go
+++ b/models/node.go
@@ -715,6 +715,15 @@ func (n *Node) Build() string {
 	return n.InfoAttr("build")
 }
 
+func (n *Node) LatencyUnits() string {
+	res := n.latestConfig.TryString("microsecond-histograms", "")
+	if res == "true" {
+		return "usec"
+	} else {
+		return "msec"
+	}
+}
+
 func (n *Node) Disk() common.Stats {
 	return common.Stats{
 		"used":             n.nsAggCalcStats.TryInt("used-bytes-disk", 0),
@@ -1131,7 +1140,7 @@ func (n *Node) parseLatenciesInfo(s string) (map[string]common.Stats, map[string
 			bucketNumber = 7 // <1ms  to >64ms
 			valBucketsFloat = valBucketsFloat[:bucketNumber]
 		} else {
-			bucketNumber = len(valBucketsFloat)
+			bucketNumber = 15
 		}
 
 		buckets := make([]string, bucketNumber)

--- a/models/node.go
+++ b/models/node.go
@@ -1085,7 +1085,7 @@ func (n *Node) parseLatencyInfo(s string) (map[string]common.Stats, map[string]c
 }
 
 func (n *Node) parseLatenciesInfo(s string) (map[string]common.Stats, map[string]common.Stats) {
-	log.Debugf("%s", s)
+	// log.Debugf("%s", s)
 	nodeStats := map[string]common.Stats{}
 	res := map[string]common.Stats{}
 

--- a/models/node.go
+++ b/models/node.go
@@ -1136,7 +1136,13 @@ func (n *Node) parseLatenciesInfo(s string) (map[string]common.Stats, map[string
 
 		buckets := make([]string, bucketNumber)
 		for i := 0; i < bucketNumber; i++ {
-			buckets[i] = fmt.Sprintf(">%d %s", 1<<i, histUnit)
+			var histUnitDisplay string
+			if histUnit == "msec" {
+				histUnitDisplay = "ms"
+			} else if histUnit == "usec" {
+				histUnitDisplay = "us"
+			}
+			buckets[i] = fmt.Sprintf(">%d%s", 1<<i, histUnitDisplay)
 		}
 
 		// calc precise in-between percents
@@ -1150,7 +1156,12 @@ func (n *Node) parseLatenciesInfo(s string) (map[string]common.Stats, map[string
 			valBucketsFloat[i] *= opsCount
 		}
 
-		current := time.Now()
+		location, err := time.LoadLocation("GMT")
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		current := time.Now().In(location)
 		timestamp := current.Format("15:04:05")
 		timestamp += "-GMT"
 

--- a/static/js/models/latency/nodemodel.js
+++ b/static/js/models/latency/nodemodel.js
@@ -106,7 +106,7 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
               changeTimestamp(data);
             }
           }
-          
+
           // sum total data
           if(_.isArray(category[1].data)) {
             changeTimestamp(category[1].data);
@@ -241,7 +241,7 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 			function successHandler(response){
 				var updateCounts = response.latency_history.length;
 
-        model.updateTimeZone();
+        		model.updateTimeZone();
 				for(var i = 0; i < updateCounts ; i++){
 					var latencyAvailable = false;
 					var latency = response.latency_history[i];
@@ -370,11 +370,21 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					if(latency[attr].data[i][bucket].pct !== null)
 						pct = latency[attr].data[i][bucket].pct.toFixed(2) + "%";
 
-					that.latencyData[attr][0].data[i].data.push({x : timestamp, y : value, secondary : pct});
-					that.legend.push({color : that.colorScale[i], title : bucket});
+					// console.log("WTF")
+					if(that.latencyData[attr][0].data[i].data.indexOf({x : timestamp, y : value, secondary : pct}) === -1) {
+						that.latencyData[attr][0].data[i].data.push({x : timestamp, y : value, secondary : pct});
+						that.legend.push({color : that.colorScale[i], title : bucket});
+					} else {
+						console.log("Latency item already exists")
+					}
+					
 				}
-				that.latencyData[attr][1].data.push({x : timestamp, y : latency[attr]["ops/sec"], secondary : "100.00%"});
-				that.legend.push({color : "#333", title : "Ops/Sec"});
+				if(that.latencyData[attr][1].data.indexOf({x : timestamp, y : latency[attr]["ops/sec"], secondary : "100.00%"}) === -1) {
+					that.latencyData[attr][1].data.push({x : timestamp, y : latency[attr]["ops/sec"], secondary : "100.00%"});
+					that.legend.push({color : "#333", title : "Ops/Sec"});
+				} else {
+					console.log("Latency total already exists")
+				}
             }
         },
 

--- a/static/js/models/latency/nodemodel.js
+++ b/static/js/models/latency/nodemodel.js
@@ -1,5 +1,5 @@
 /******************************************************************************
-*Copyright 2008-2014 by Aerospike, Inc. All rights reserved.
+*Copyright 2008-2020 by Aerospike, Inc. All rights reserved.
 *THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE. THE COPYRIGHT NOTICE
 *ABOVE DOES NOT EVIDENCE ANY ACTUAL OR INTENDED PUBLICATION.
 ******************************************************************************/
@@ -11,7 +11,8 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 			this.modelID = this.get("model_id");
 			this.address = this.get("address");
 			this.clusterID = window.AMCGLOBALS.persistent.clusterID;//this.get("cluster_id");
-			this.colorScale = ["#5ACC44", "#E2BE00", "#ff7f0e", "#d62728", "#1f75fe", "#b5674d", "#926eae", "#ffaacc", "#199ebd", "#fdd9b5", "#1dacd6", "#cd4a4a", "#000000"];
+			this.colorScale = ["#5ACC44", "#E2BE00", "#ff7f0e", "#d62728", "#1f75fe", "#b5674d", "#926eae", "#ffaacc", "#199ebd", 
+							   "#fdd9b5", "#1dacd6", "#cd4a4a", "#566d54", "#f39385", "#e6e6fa", "#b49270", "#000000"];
 			this.polling = true;
 			this.latencyData = null;
 			this.legend;
@@ -37,7 +38,8 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 
 		initLatencyHistory: function (history) {
 			this.attributes.node_status = history.node_status || "off";
-			this.attributes.node_build = history.node_build || "5.0.0.0"
+			this.attributes.node_build = history.node_build || "5.0.0.0";
+			this.attributes.latency_units = history.latency_units || "msec";
 
 			if (history.latency_history != null && history.latency_history.length > 0) {
 
@@ -382,13 +384,13 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					if (latency[attr].data[i][bucket].pct !== null)
 						pct = latency[attr].data[i][bucket].pct.toFixed(2) + "%";
 
-					if (that.latencyData[attr][0].data[i].data.length == 0  ||
+					if (that.latencyData[attr][0].data[i].data.length == 0 ||
 						that.latencyData[attr][0].data[i].data.slice(-1)[0].x != timestampUnix) {
 						that.latencyData[attr][0].data[i].data.push({ x: timestampUnix, y: value, secondary: pct });
 						that.legend.push({ color: that.colorScale[i], title: bucket });
-						console.debug("Latency item:" + attr + ":" + i + ":" + timestampUnix + ":" + value + ":" + pct)
+						console.debug("Latency item:" + attr + ":" + i + ":" + timestampUnix + ":" + value + ":" + pct);
 					} else {
-						console.log("First item or Latency item already exists: " + timestampUnix)
+						console.debug("First item or Latency item already exists: " + timestampUnix);
 					}
 
 				}
@@ -396,9 +398,9 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					that.latencyData[attr][1].data.slice(-1)[0].x != timestampUnix) {
 					that.latencyData[attr][1].data.push({ x: timestampUnix, y: latency[attr]["ops/sec"], secondary: "100.00%" });
 					that.legend.push({ color: "#333", title: "Ops/Sec" });
-					console.debug("Latency ops :" + attr + ":" + " :" + timestampUnix + ":" + latency[attr]["ops/sec"])
+					console.debug("Latency ops :" + attr + ":" + " :" + timestampUnix + ":" + latency[attr]["ops/sec"]);
 				} else {
-					console.log("First item or Latency total already exists: " + timestampUnix)
+					console.debug("First item or Latency total already exists: " + timestampUnix);
 				}
 			}
 		},
@@ -416,7 +418,7 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					}
 
 					currentLatencyTimestampUnix = currentLatencyTimestampUnix || latency[attr].timestamp_unix * 1000;
-					if (lastTimestampUnix == null ) {
+					if (lastTimestampUnix == null) {
 						lastTimestampUnix = model.latencyData[attr][0].data[0].data[model.latencyData[attr][0].data[0].data.length - 1].x;
 					}
 
@@ -507,18 +509,39 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 						{ '>64ms': { 'pct': null, 'value': null } }]
 				};
 			} else {
-				var nullData = {
-					'ops/sec': null, data: [
-						{ '&#x2264;1ms': { 'pct': null, 'value': null } },
-						{ '>1ms to &#x2264;2ms': { 'pct': null, 'value': null } },
-						{ '>2ms to &#x2264;4ms': { 'pct': null, 'value': null } },
-						{ '>4ms to &#x2264;8ms': { 'pct': null, 'value': null } },
-						{ '>8ms to &#x2264;16ms': { 'pct': null, 'value': null } },
-						{ '>16ms to &#x2264;32ms': { 'pct': null, 'value': null } },
-						{ '>32ms to &#x2264;64ms': { 'pct': null, 'value': null } },
-						{ '>64ms': { 'pct': null, 'value': null } }]
-				};
-
+				if (that.attributes.latency_units == "usec") {
+					var nullData = {
+						'ops/sec': null, data: [
+							{ '&#x2264;1us': { 'pct': null, 'value': null } },
+							{ '>1us to &#x2264;2us': { 'pct': null, 'value': null } },
+							{ '>2us to &#x2264;4us': { 'pct': null, 'value': null } },
+							{ '>4us to &#x2264;8us': { 'pct': null, 'value': null } },
+							{ '>8us to &#x2264;16us': { 'pct': null, 'value': null } },
+							{ '>16us to &#x2264;32us': { 'pct': null, 'value': null } },
+							{ '>32us to &#x2264;64us': { 'pct': null, 'value': null } },
+							{ '>64us to &#x2264;128us': { 'pct': null, 'value': null } },
+							{ '>128us to &#x2264;256us': { 'pct': null, 'value': null } },
+							{ '>256us to &#x2264;512us': { 'pct': null, 'value': null } },
+							{ '>512us to &#x2264;1024us': { 'pct': null, 'value': null } },
+							{ '>1024us to &#x2264;2048us': { 'pct': null, 'value': null } },
+							{ '>2048us to &#x2264;4096us': { 'pct': null, 'value': null } },
+							{ '>4096us to &#x2264;8192us': { 'pct': null, 'value': null } },
+							{ '>8192us to &#x2264;16384us': { 'pct': null, 'value': null } },
+							{ '>16384us': { 'pct': null, 'value': null } }]
+					};
+				} else {
+					var nullData = {
+						'ops/sec': null, data: [
+							{ '&#x2264;1ms': { 'pct': null, 'value': null } },
+							{ '>1ms to &#x2264;2ms': { 'pct': null, 'value': null } },
+							{ '>2ms to &#x2264;4ms': { 'pct': null, 'value': null } },
+							{ '>4ms to &#x2264;8ms': { 'pct': null, 'value': null } },
+							{ '>8ms to &#x2264;16ms': { 'pct': null, 'value': null } },
+							{ '>16ms to &#x2264;32ms': { 'pct': null, 'value': null } },
+							{ '>32ms to &#x2264;64ms': { 'pct': null, 'value': null } },
+							{ '>64ms': { 'pct': null, 'value': null } }]
+					};
+				}
 			}
 
 			nullData.timestamp = (timestamp.getHours() < 10 ? ("0" + timestamp.getHours()) : ("" + timestamp.getHours())) + ":";

--- a/static/js/models/latency/nodemodel.js
+++ b/static/js/models/latency/nodemodel.js
@@ -386,10 +386,9 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 						that.latencyData[attr][0].data[i].data.slice(-1)[0].x != timestampUnix) {
 						that.latencyData[attr][0].data[i].data.push({ x: timestampUnix, y: value, secondary: pct });
 						that.legend.push({ color: that.colorScale[i], title: bucket });
-						console.log("Latency item:" + attr + ":" + i + ":" + timestampUnix + ":" + value + ":" + pct)
-
+						console.debug("Latency item:" + attr + ":" + i + ":" + timestampUnix + ":" + value + ":" + pct)
 					} else {
-						console.log("Latency item already exists")
+						console.log("First item or Latency item already exists: " + timestampUnix)
 					}
 
 				}
@@ -397,9 +396,9 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					that.latencyData[attr][1].data.slice(-1)[0].x != timestampUnix) {
 					that.latencyData[attr][1].data.push({ x: timestampUnix, y: latency[attr]["ops/sec"], secondary: "100.00%" });
 					that.legend.push({ color: "#333", title: "Ops/Sec" });
-					console.log("Latency ops :" + attr + ":" + " :" + timestampUnix + ":" + latency[attr]["ops/sec"])
+					console.debug("Latency ops :" + attr + ":" + " :" + timestampUnix + ":" + latency[attr]["ops/sec"])
 				} else {
-					console.log("Latency total already exists")
+					console.log("First item or Latency total already exists: " + timestampUnix)
 				}
 			}
 		},

--- a/static/js/models/latency/nodemodel.js
+++ b/static/js/models/latency/nodemodel.js
@@ -3,17 +3,17 @@
 *THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE. THE COPYRIGHT NOTICE
 *ABOVE DOES NOT EVIDENCE ANY ACTUAL OR INTENDED PUBLICATION.
 ******************************************************************************/
-define(["underscore", "backbone", "poller", "config/app-config", "views/latency/nodeview", "d3", "helper/util",'helper/AjaxManager', "views/latency/nodeview"], function(_, Backbone, Poller, AppConfig, NodeView, D3, Util,AjaxManager, NodeView){
-    var NodeModel = Backbone.Model.extend({
-        initVariables :function(){
-            this.expanded = {};
+define(["underscore", "backbone", "poller", "config/app-config", "views/latency/nodeview", "d3", "helper/util", 'helper/AjaxManager', "views/latency/nodeview"], function (_, Backbone, Poller, AppConfig, NodeView, D3, Util, AjaxManager, NodeView) {
+	var NodeModel = Backbone.Model.extend({
+		initVariables: function () {
+			this.expanded = {};
 			this.historyInitialized = false;
-            this.modelID = this.get("model_id");
-            this.address = this.get("address");
-            this.clusterID = window.AMCGLOBALS.persistent.clusterID;//this.get("cluster_id");
+			this.modelID = this.get("model_id");
+			this.address = this.get("address");
+			this.clusterID = window.AMCGLOBALS.persistent.clusterID;//this.get("cluster_id");
 			this.colorScale = ["#5ACC44", "#E2BE00", "#ff7f0e", "#d62728", "#1f75fe", "#b5674d", "#926eae", "#ffaacc", "#199ebd", "#fdd9b5", "#1dacd6", "#cd4a4a", "#000000"];
-            this.polling = true;
-            this.latencyData = null;
+			this.polling = true;
+			this.latencyData = null;
 			this.legend;
 			this.latencyAvailable = false;
 			this.latencyDataDate = {};
@@ -21,134 +21,134 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 			this.attrList = ["writes_master", "writes", "reads", "proxy", "udf", "query"];
 			this.rowView = new NodeView(this);
 			this.startEventListeners();
-       this.useLocalTimezone = Util.useLocalTimezone();
-        },
+			this.useLocalTimezone = Util.useLocalTimezone();
+		},
 
-      initialize :function(model){
-        this.CID = window.AMCGLOBALS.currentCID;
-        try{
-          this.initVariables();
-        } catch(e) {
-          console.log(e);
-        }
-      },
+		initialize: function (model) {
+			this.CID = window.AMCGLOBALS.currentCID;
+			try {
+				this.initVariables();
+			} catch (e) {
+				console.log(e);
+			}
+		},
 
-      initLatencyHistory: function(history) {
-		this.attributes.node_status = history.node_status || "off";
-		this.attributes.node_build  = history.node_build || "5.0.0.0"
+		initLatencyHistory: function (history) {
+			this.attributes.node_status = history.node_status || "off";
+			this.attributes.node_build = history.node_build || "5.0.0.0"
 
-        if(history.latency_history != null && history.latency_history.length > 0){
+			if (history.latency_history != null && history.latency_history.length > 0) {
 
-		  var latencyHistory = history.latency_history;
+				var latencyHistory = history.latency_history;
 
-		  latencyHistory = this.prependAndFillNullLatencyData(history.latency_history); 
+				latencyHistory = this.prependAndFillNullLatencyData(history.latency_history);
 
-          if(latencyHistory.length > 0){
-            this.pushLatencyInfoHistory(this, latencyHistory);
-            this.latencyAvailable = true;
-            this.rowView.initContainers(this);
-          }
-        }
+				if (latencyHistory.length > 0) {
+					this.pushLatencyInfoHistory(this, latencyHistory);
+					this.latencyAvailable = true;
+					this.rowView.initContainers(this);
+				}
+			}
 
-        if(this.latencyAvailable || history.node_status !== "on"){
-          this.rowView.render(this,this.latencyData);
-        } else {
-          this.rowView.error(this);
-        }
-        this.historyInitialized = true;
-      },
+			if (this.latencyAvailable || history.node_status !== "on") {
+				this.rowView.render(this, this.latencyData);
+			} else {
+				this.rowView.error(this);
+			}
+			this.historyInitialized = true;
+		},
 
-      initLatencyHistoryOnError: function() {
-        this.historyInitialized = true;
-	  },
-	  
-      getCurrentDate: function() {
-        var now = new Date();
-        if(this.useLocalTimezone) {
-          return now;
-        } else {
-          return new Date(now.getTime() + now.getTimezoneOffset()*60*1000);
-        }
-      },
+		initLatencyHistoryOnError: function () {
+			this.historyInitialized = true;
+		},
 
-      getDateByTimestamp: function(timestamp) {
-        var now = new Date();
-        if(this.useLocalTimezone) {
-          return new Date(timestamp);
-        } else {
-          return new Date(timestamp + now.getTimezoneOffset()*60*1000);
-        }
-      },
+		getCurrentDate: function () {
+			var now = new Date();
+			if (this.useLocalTimezone) {
+				return now;
+			} else {
+				return new Date(now.getTime() + now.getTimezoneOffset() * 60 * 1000);
+			}
+		},
 
-      getDateByUnixTimestamp: function(timestamp) {
-        var now = new Date();
-		return new Date(timestamp);
-      },
+		getDateByTimestamp: function (timestamp) {
+			var now = new Date();
+			if (this.useLocalTimezone) {
+				return new Date(timestamp);
+			} else {
+				return new Date(timestamp + now.getTimezoneOffset() * 60 * 1000);
+			}
+		},
 
-      updateTimeZone: function() {
-        var plocal = this.useLocalTimezone;
-        this.useLocalTimezone = Util.useLocalTimezone();
-        var useLocalTimezone = this.useLocalTimezone;
-        if(plocal === useLocalTimezone) {
-          return;
-        }
+		getDateByUnixTimestamp: function (timestamp) {
+			var now = new Date();
+			return new Date(timestamp);
+		},
 
-        var that = this;
-        var category; // total, < 1ms, < 5ms, < 8ms, etc
-        var data, cdata;
-        var attr; // reads, writes, etc
-        var i;
-        for(attr in this.latencyData) {
-          if(!this.latencyData.hasOwnProperty(attr)) {
-            continue;
-          }
-          category = this.latencyData[attr];
+		updateTimeZone: function () {
+			var plocal = this.useLocalTimezone;
+			this.useLocalTimezone = Util.useLocalTimezone();
+			var useLocalTimezone = this.useLocalTimezone;
+			if (plocal === useLocalTimezone) {
+				return;
+			}
 
-          // category data
-          cdata = category[0].data;
-          if(cdata) {
-            for(i = 0; i < cdata.length; i++) {
-              data = cdata[i].data;
-              changeTimestamp(data);
-            }
-          }
+			var that = this;
+			var category; // total, < 1ms, < 5ms, < 8ms, etc
+			var data, cdata;
+			var attr; // reads, writes, etc
+			var i;
+			for (attr in this.latencyData) {
+				if (!this.latencyData.hasOwnProperty(attr)) {
+					continue;
+				}
+				category = this.latencyData[attr];
 
-          // sum total data
-          if(_.isArray(category[1].data)) {
-            changeTimestamp(category[1].data);
-          }
-        }
+				// category data
+				cdata = category[0].data;
+				if (cdata) {
+					for (i = 0; i < cdata.length; i++) {
+						data = cdata[i].data;
+						changeTimestamp(data);
+					}
+				}
 
-        return;
+				// sum total data
+				if (_.isArray(category[1].data)) {
+					changeTimestamp(category[1].data);
+				}
+			}
 
-        function changeTimestamp(data) {
-          var i, x, d;
-          var now = new Date();
-          var delta = now.getTimezoneOffset()*60*1000;
-          for(i = 0; i < data.length; i++) {
-            d = data[i];
-            // toggle time zone
-            if(useLocalTimezone) {
-              d.x = d.x - delta;
-            } else {
-              d.x = d.x + delta;
-            }
-          }
-        }
-      },
+			return;
 
-        fetchSuccess: function(model){
-			if(model.CID !== window.AMCGLOBALS.currentCID){
+			function changeTimestamp(data) {
+				var i, x, d;
+				var now = new Date();
+				var delta = now.getTimezoneOffset() * 60 * 1000;
+				for (i = 0; i < data.length; i++) {
+					d = data[i];
+					// toggle time zone
+					if (useLocalTimezone) {
+						d.x = d.x - delta;
+					} else {
+						d.x = d.x + delta;
+					}
+				}
+			}
+		},
+
+		fetchSuccess: function (model) {
+			if (model.CID !== window.AMCGLOBALS.currentCID) {
 				model.rowView.cleanView(model.rowView);
 				model.destroy();
 			}
-			if(model.historyInitialized){
+			if (model.historyInitialized) {
 				var latencyAvailable = false;
 				var latency = model.attributes.latency;
 
-        		model.updateTimeZone();
-				if(model.attributes.node_status === "on"){
-					for(var attr in model.attributes.latency){
+				model.updateTimeZone();
+				if (model.attributes.node_status === "on") {
+					for (var attr in model.attributes.latency) {
 						latencyAvailable = true;
 						break;
 					}
@@ -160,12 +160,12 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					break;
 				}
 
-				if(model.latencyAvailable && !latencyAvailable){
+				if (model.latencyAvailable && !latencyAvailable) {
 					latency = model.getNullInfo(new Date((model.latencyData[attr_name][0].data[0].data[model.latencyData[attr_name][0].data[0].data.length - 1].x) + 10000));
 					latencyAvailable = true;
 				}
 
-				if(!model.latencyAvailable && latencyAvailable){
+				if (!model.latencyAvailable && latencyAvailable) {
 
 					var latencyHistory = [model.attributes.latency];
 
@@ -176,23 +176,23 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 					model.rowView.initContainers(model);
 				}
 
-				if(model.latencyAvailable && latencyAvailable){
-					model.shiftLatencyInfo(model, latency );
+				if (model.latencyAvailable && latencyAvailable) {
+					model.shiftLatencyInfo(model, latency);
 				}
 
-				if(model.latencyAvailable)
-					model.rowView.render(model,model.latencyData);
+				if (model.latencyAvailable)
+					model.rowView.render(model, model.latencyData);
 			}
 
 
-			if(typeof model.attributes.error !== 'undefined' && model.attributes.error.indexOf("Invalid cluster id") != -1){
+			if (typeof model.attributes.error !== 'undefined' && model.attributes.error.indexOf("Invalid cluster id") != -1) {
 				delete model.attributes.error;
 				Util.clusterIDReset();
 			}
-        },
+		},
 
-        fetchError: function(model){
-			if(model.CID !== window.AMCGLOBALS.currentCID){
+		fetchError: function (model) {
+			if (model.CID !== window.AMCGLOBALS.currentCID) {
 				model.rowView.cleanView(model.rowView);
 				model.destroy();
 			}
@@ -203,66 +203,66 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 				break;
 			}
 
-			if(model.latencyAvailable){
+			if (model.latencyAvailable) {
 				latency = model.getNullInfo(new Date((model.latencyData[attr_name][0].data[0].data[model.latencyData[attr_name][0].data[0].data.length - 1].x) + 10000));
 				latencyAvailable = true;
-				model.shiftLatencyInfo(model, latency );
-				model.rowView.render(model,model.latencyData);
+				model.shiftLatencyInfo(model, latency);
+				model.rowView.render(model, model.latencyData);
 			}
 
 			console.info("err");
-        },
+		},
 
-        startEventListeners : function (){
-            var that = this;
-            this.on('remove',function(){
-            	that.rowView.cleanView(that.rowView);
-            	$('#' + Util.removeDotAndColon(that.address)+'-nodeLatencyContainer').remove();
-            });
+		startEventListeners: function () {
+			var that = this;
+			this.on('remove', function () {
+				that.rowView.cleanView(that.rowView);
+				$('#' + Util.removeDotAndColon(that.address) + '-nodeLatencyContainer').remove();
+			});
 
-            function viewDestroy(){
-            	$(document).off("view:Destroy", viewDestroy).off("pollerResume", globalPollinghandler);
-            	that.rowView.cleanView(that.rowView);
-                that.destroy();
-            };
+			function viewDestroy() {
+				$(document).off("view:Destroy", viewDestroy).off("pollerResume", globalPollinghandler);
+				that.rowView.cleanView(that.rowView);
+				that.destroy();
+			};
 
-            function globalPollinghandler(event){
+			function globalPollinghandler(event) {
 				event.data.model.historyInitialized = false;
 				event.data.model.insertSliceHistory(event.data.model);
 
 			};
 
-            $(document).on("view:Destroy", viewDestroy);
-            $(document).off("pollerResume", globalPollinghandler).on("pollerResume", {model : that}, globalPollinghandler);
+			$(document).on("view:Destroy", viewDestroy);
+			$(document).off("pollerResume", globalPollinghandler).on("pollerResume", { model: that }, globalPollinghandler);
 
-        },
+		},
 
-        insertSliceHistory: function(model){
+		insertSliceHistory: function (model) {
 			AjaxManager.sendRequest(AppConfig.baseUrl + window.AMCGLOBALS.persistent.clusterID + '/latency_history/' + this.address,
-				{async: true},
+				{ async: true },
 				successHandler,
 				errorHandler
 			);
 
-			function successHandler(response){
+			function successHandler(response) {
 				var updateCounts = response.latency_history.length;
 
-        		model.updateTimeZone();
-				for(var i = 0; i < updateCounts ; i++){
+				model.updateTimeZone();
+				for (var i = 0; i < updateCounts; i++) {
 					var latencyAvailable = false;
 					var latency = response.latency_history[i];
 
-					for(var attr in latency){
+					for (var attr in latency) {
 						latencyAvailable = true;
 						break;
 					}
 
-					if(model.latencyAvailable && !latencyAvailable){
+					if (model.latencyAvailable && !latencyAvailable) {
 						latency = model.getNullInfo(new Date((model.latencyData['writes'][0].data[0].data[model.latencyData['writes'][0].data[0].data.length - 1].x) + 10000));
 						latencyAvailable = true;
 					}
 
-					if(!model.latencyAvailable && latencyAvailable){
+					if (!model.latencyAvailable && latencyAvailable) {
 						var latencyHistory = [latency];
 						latencyHistory = model.prependAndFillNullLatencyData(latencyHistory);
 						model.pushLatencyInfoHistory(model, latencyHistory);
@@ -270,86 +270,86 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 						model.rowView.initContainers(model);
 					}
 
-					if(model.latencyAvailable && latencyAvailable){
-						model.shiftLatencyInfo(model, latency );
+					if (model.latencyAvailable && latencyAvailable) {
+						model.shiftLatencyInfo(model, latency);
 					}
 				}
 
-				if(model.latencyAvailable)
-					model.rowView.render(model,model.latencyData);
+				if (model.latencyAvailable)
+					model.rowView.render(model, model.latencyData);
 
 				model.historyInitialized = true;
-            };
+			};
 
-            function errorHandler(response){
-            	model.historyInitialized = true;
-            }
+			function errorHandler(response) {
+				model.historyInitialized = true;
+			}
 
 		},
 
-        pushLatencyInfoHistory: function(view,latencyHistory){
+		pushLatencyInfoHistory: function (view, latencyHistory) {
 			var that = this;
-			if(typeof latencyHistory !== 'undefined' && latencyHistory !== null){
+			if (typeof latencyHistory !== 'undefined' && latencyHistory !== null) {
 				var currentLatencyTimestamp, lastTimestamp;
-				for(var i=0; i<latencyHistory.length; i++){
+				for (var i = 0; i < latencyHistory.length; i++) {
 					for (var attr in that.attrList) {
 						if (attr) {
 							currentLatencyTimestamp = latencyHistory[i][that.attrList[0]].timestamp;
 							break
 						}
 					}
-					if(currentLatencyTimestamp !== lastTimestamp) {
-						view.pushLatencyInfo(view,latencyHistory[i]);
-          }
+					if (currentLatencyTimestamp !== lastTimestamp) {
+						view.pushLatencyInfo(view, latencyHistory[i]);
+					}
 					lastTimestamp = currentLatencyTimestamp;
 				}
 			}
-        },
+		},
 
-        pushLatencyInfo: function(view,latency){
+		pushLatencyInfo: function (view, latency) {
 			var that = this;
 
-			if(typeof that.latencyData === 'undefined' || that.latencyData === null){
+			if (typeof that.latencyData === 'undefined' || that.latencyData === null) {
 				that.latencyData = {};
 
-				for(var attr in latency){
+				for (var attr in latency) {
 					that.latencyData[attr] = [];
 					that.latencyData[attr].push({
-						name : "Node_" + that.address.replace(/\./g,"_").replace(/\:/g,"_") + "_" + attr,
-						title : attr,
-						renderer : "stacked area",
-						highlight : false,
-						disabled : false,
-						data : []
+						name: "Node_" + that.address.replace(/\./g, "_").replace(/\:/g, "_") + "_" + attr,
+						title: attr,
+						renderer: "stacked area",
+						highlight: false,
+						disabled: false,
+						data: []
 					});
 
 					that.latencyData[attr].push({
-						name : "Node_" + that.address.replace(/\./g,"_").replace(/\:/g,"_") + "_" + attr + "_ops",
-						title : "Total Ops" + "  [" + attr + "]",
-						subTitle : "Total Ops" + "  [" + attr + "]",
-						renderer : "line",
-						color : "#333",
-						disabled : true,
-						data : []
+						name: "Node_" + that.address.replace(/\./g, "_").replace(/\:/g, "_") + "_" + attr + "_ops",
+						title: "Total Ops" + "  [" + attr + "]",
+						subTitle: "Total Ops" + "  [" + attr + "]",
+						renderer: "line",
+						color: "#333",
+						disabled: true,
+						data: []
 					});
 				}
 			}
 
 
-			if(_.isEmpty(this.latencyDataDate)){
+			if (_.isEmpty(this.latencyDataDate)) {
 				var currentTime = this.getCurrentDate();
-				for(var attr in latency){
+				for (var attr in latency) {
 					this.latencyDataDate[attr] = this.getCurrentDate();
 				}
 			}
 
-            for(var attr in latency){
+			for (var attr in latency) {
 
-                var timestamp = this.getDateByTimestamp(latency[attr].timestamp_unix*1000);
+				var timestamp = this.getDateByTimestamp(latency[attr].timestamp_unix * 1000);
 
-				if(this.lastTimestamp[attr] != null){
-					if((timestamp.getTime() - this.lastTimestamp[attr].getTime()) <= -10000){
-            // TODO dont know the purpose of these
+				if (this.lastTimestamp[attr] != null) {
+					if ((timestamp.getTime() - this.lastTimestamp[attr].getTime()) <= -10000) {
+						// TODO dont know the purpose of these
 						// xxx this.latencyDataDate[attr].setDate( this.latencyDataDate[attr].getDate() + 1 );
 						// xxx timestamp = new Date(this.latencyDataDate[attr].getFullYear() + "/" + (this.latencyDataDate[attr].getMonth() + 1) + "/" + this.latencyDataDate[attr].getDate() + " " + latency[attr].timestamp);
 					}
@@ -358,57 +358,57 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 				this.lastTimestamp[attr] = timestamp;
 				timestamp = +timestamp.getTime();
 
-                that.legend = [];
-				for(var i=0; i<latency[attr].data.length; i++){
+				that.legend = [];
+				for (var i = 0; i < latency[attr].data.length; i++) {
 					var bucket = "";
 
-					for(var key in latency[attr].data[i]){
+					for (var key in latency[attr].data[i]) {
 						bucket = key;
 						break;
 					}
 
-					if(!(typeof that.latencyData[attr][0].data[i] !== 'undefined' && that.latencyData[attr][0].data[i].name === bucket)){
-						that.latencyData[attr][0].data[i] = {name : bucket, title : bucket, color : that.colorScale[i], data : []};
+					if (!(typeof that.latencyData[attr][0].data[i] !== 'undefined' && that.latencyData[attr][0].data[i].name === bucket)) {
+						that.latencyData[attr][0].data[i] = { name: bucket, title: bucket, color: that.colorScale[i], data: [] };
 					}
 
 					var pct = null;
 					var value = latency[attr].data[i][bucket].value;
-					if(latency[attr].data[i][bucket].pct !== null)
+					if (latency[attr].data[i][bucket].pct !== null)
 						pct = latency[attr].data[i][bucket].pct.toFixed(2) + "%";
 
-					if(that.latencyData[attr][0].data[i].data.indexOf({x : timestamp, y : value, secondary : pct}) === -1) {
-						that.latencyData[attr][0].data[i].data.push({x : timestamp, y : value, secondary : pct});
-						that.legend.push({color : that.colorScale[i], title : bucket});
-						console.log("Latency item:" + attr + ":" + i + ":" +timestamp + ":" + value + ":" + pct)
+					if (that.latencyData[attr][0].data[i].data.indexOf({ x: timestamp, y: value, secondary: pct }) === -1) {
+						that.latencyData[attr][0].data[i].data.push({ x: timestamp, y: value, secondary: pct });
+						that.legend.push({ color: that.colorScale[i], title: bucket });
+						console.log("Latency item:" + attr + ":" + i + ":" + timestamp + ":" + value + ":" + pct)
 
 					} else {
 						console.log("Latency item already exists")
 					}
-					
+
 				}
-				if(that.latencyData[attr][1].data.indexOf({x : timestamp, y : latency[attr]["ops/sec"], secondary : "100.00%"}) === -1) {
-					that.latencyData[attr][1].data.push({x : timestamp, y : latency[attr]["ops/sec"], secondary : "100.00%"});
-					that.legend.push({color : "#333", title : "Ops/Sec"});
-					console.log("Latency ops :" + attr + ":" + " :" +timestamp + ":" + latency[attr]["ops/sec"])
+				if (that.latencyData[attr][1].data.indexOf({ x: timestamp, y: latency[attr]["ops/sec"], secondary: "100.00%" }) === -1) {
+					that.latencyData[attr][1].data.push({ x: timestamp, y: latency[attr]["ops/sec"], secondary: "100.00%" });
+					that.legend.push({ color: "#333", title: "Ops/Sec" });
+					console.log("Latency ops :" + attr + ":" + " :" + timestamp + ":" + latency[attr]["ops/sec"])
 				} else {
 					console.log("Latency total already exists")
 				}
-            }
-        },
+			}
+		},
 
-        shiftLatencyInfo: function(model,latency){
-			if(latency !== null){
+		shiftLatencyInfo: function (model, latency) {
+			if (latency !== null) {
 				var currentTime, lastTimestamp, currentLatencyTimestamp;
 
-				for(var attr in model.latencyData){
+				for (var attr in model.latencyData) {
 
-					if(!_.isEmpty(this.latencyDataDate)){
+					if (!_.isEmpty(this.latencyDataDate)) {
 						currentTime = this.latencyDataDate[attr];
-					} else{
+					} else {
 						currentTime = this.getCurrentDate();
 					}
 					currentLatencyTimestamp = currentLatencyTimestamp || latency[attr].timestamp;
-					if(lastTimestamp == null){
+					if (lastTimestamp == null) {
 						lastTimestamp = this.getDateByTimestamp(model.latencyData[attr][0].data[0].data[model.latencyData[attr][0].data[0].data.length - 1].x);
 						var hours = (hours = lastTimestamp.getHours()) < 10 ? ("0" + hours) : hours;
 						var minutes = (minutes = lastTimestamp.getMinutes()) < 10 ? ("0" + minutes) : minutes;
@@ -417,60 +417,60 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 						lastTimestamp = hours + ":" + minutes + ":" + seconds;
 					}
 
-					if(currentLatencyTimestamp !== lastTimestamp){
-						for(var i=0; i< model.latencyData[attr][0].data.length; i++){
+					if (currentLatencyTimestamp !== lastTimestamp) {
+						for (var i = 0; i < model.latencyData[attr][0].data.length; i++) {
 							model.latencyData[attr][0].data[i].data.shift();
 						}
 						model.latencyData[attr][1].data.shift();
 					}
 				}
 
-        		model.pushLatencyInfo(model,latency);
+				model.pushLatencyInfo(model, latency);
 			}
-        },
-
-		updateWindow: function(timeWindowSize, fixTimeWindowSize) {
-		this.rowView.updateWindow(this, this.latencyData, timeWindowSize, fixTimeWindowSize);
 		},
 
-		prependAndFillNullLatencyData: function(latencyResponse){
+		updateWindow: function (timeWindowSize, fixTimeWindowSize) {
+			this.rowView.updateWindow(this, this.latencyData, timeWindowSize, fixTimeWindowSize);
+		},
+
+		prependAndFillNullLatencyData: function (latencyResponse) {
 			var that = this;
 			var latencyData = latencyResponse;
 			var minDataPoints = 180;
 			var firstTimestamp = '';
 			var firstTimestampIndex = -1;
 
-			for(var i=0, blank = true; i<latencyData.length && blank == true; i++){
-				for(var attr in latencyData[i]){
+			for (var i = 0, blank = true; i < latencyData.length && blank == true; i++) {
+				for (var attr in latencyData[i]) {
 					blank = false;
 					that.attrList = _.intersection(that.attrList, _.keys(latencyResponse[i]));
 					if (latencyData[i][attr]) {
-						firstTimestamp = latencyData[i][attr].timestamp_unix*1000;
+						firstTimestamp = latencyData[i][attr].timestamp_unix * 1000;
 						firstTimestampIndex = i;
 						break;
 					}
 				}
 			}
 
-			if(firstTimestampIndex == -1)
+			if (firstTimestampIndex == -1)
 				return [];
 
-            var timestamp = firstTimestamp;
+			var timestamp = firstTimestamp;
 
 			var lastTimestamp = firstTimestamp;
 
-			for(var i = firstTimestampIndex + 1; i<latencyData.length; i++){
+			for (var i = firstTimestampIndex + 1; i < latencyData.length; i++) {
 				var blank = true;
-				for(var attr in latencyData[i]){
+				for (var attr in latencyData[i]) {
 					blank = false;
-					lastTimestamp = latencyData[i][attr].timestamp_unix*1000;
+					lastTimestamp = latencyData[i][attr].timestamp_unix * 1000;
 					break;
 				}
 
-				if(blank){
+				if (blank) {
 					newTimestamp = that.getDateByTimestamp(lastTimestamp);
 					newTimestamp.setSeconds(newTimestamp.getSeconds() + 10);
-          lastTimestamp = newTimestamp.getTime();
+					lastTimestamp = newTimestamp.getTime();
 					latencyData[i] = that.getNullInfo(new Date(newTimestamp.getTime() + 10000));
 				}
 			}
@@ -480,12 +480,12 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 			var runIndex = 0 - missingPoints;
 			newTimestamp = that.getDateByTimestamp(lastTimestamp);
 
-			for(var i = Math.max(firstTimestampIndex, 0) - 1; i >= runIndex; i--){
+			for (var i = Math.max(firstTimestampIndex, 0) - 1; i >= runIndex; i--) {
 				newTimestamp.setSeconds(newTimestamp.getSeconds() - 10);
-        lastTimestamp = newTimestamp;
-				if(i >= 0){
+				lastTimestamp = newTimestamp;
+				if (i >= 0) {
 					latencyData[i] = that.getNullInfo(new Date(newTimestamp.getTime()));
-				} else{
+				} else {
 					latencyData.unshift(that.getNullInfo(new Date(newTimestamp.getTime())));
 				}
 			}
@@ -493,46 +493,48 @@ define(["underscore", "backbone", "poller", "config/app-config", "views/latency/
 			return latencyData;
 		},
 
-		getNullInfo : function(timestamp){
+		getNullInfo: function (timestamp) {
 			var that = this;
-			if(that.attributes.node_build < "5.1") {
-				var nullData = {'ops/sec' : null, data : [
-						{'&#x2264;1ms'  : {'pct' : null, 'value' : null}},
-						{'>1ms to &#x2264;8ms'  : {'pct' : null, 'value' : null}},
-						{'>8ms to &#x2264;64ms'  : {'pct' : null, 'value' : null}},
-						{'>64ms' : {'pct' : null, 'value' : null}}]
-					};
-				} else {
-					var nullData = {'ops/sec' : null, data : [
-						{'&#x2264;1ms'  : {'pct' : null, 'value' : null}},
-						{'>1ms to &#x2264;2ms'  : {'pct' : null, 'value' : null}},
-						{'>2ms to &#x2264;4ms'  : {'pct' : null, 'value' : null}},
-						{'>4ms to &#x2264;8ms'  : {'pct' : null, 'value' : null}},
-						{'>8ms to &#x2264;16ms'  : {'pct' : null, 'value' : null}},
-						{'>16ms to &#x2264;32ms'  : {'pct' : null, 'value' : null}},
-						{'>32ms to &#x2264;64ms'  : {'pct' : null, 'value' : null}},
-						{'>64ms' : {'pct' : null, 'value' : null}}]
-					};
+			if (that.attributes.node_build < "5.1") {
+				var nullData = {
+					'ops/sec': null, data: [
+						{ '&#x2264;1ms': { 'pct': null, 'value': null } },
+						{ '>1ms to &#x2264;8ms': { 'pct': null, 'value': null } },
+						{ '>8ms to &#x2264;64ms': { 'pct': null, 'value': null } },
+						{ '>64ms': { 'pct': null, 'value': null } }]
+				};
+			} else {
+				var nullData = {
+					'ops/sec': null, data: [
+						{ '&#x2264;1ms': { 'pct': null, 'value': null } },
+						{ '>1ms to &#x2264;2ms': { 'pct': null, 'value': null } },
+						{ '>2ms to &#x2264;4ms': { 'pct': null, 'value': null } },
+						{ '>4ms to &#x2264;8ms': { 'pct': null, 'value': null } },
+						{ '>8ms to &#x2264;16ms': { 'pct': null, 'value': null } },
+						{ '>16ms to &#x2264;32ms': { 'pct': null, 'value': null } },
+						{ '>32ms to &#x2264;64ms': { 'pct': null, 'value': null } },
+						{ '>64ms': { 'pct': null, 'value': null } }]
+				};
 
-				}
+			}
 
 			nullData.timestamp = (timestamp.getHours() < 10 ? ("0" + timestamp.getHours()) : ("" + timestamp.getHours())) + ":";
 			nullData.timestamp += (timestamp.getMinutes() < 10 ? ("0" + timestamp.getMinutes()) : ("" + timestamp.getMinutes())) + ":";
 			nullData.timestamp += (timestamp.getSeconds() < 10 ? ("0" + timestamp.getSeconds()) : ("" + timestamp.getSeconds()));
-      		nullData.timestamp_unix = Math.ceil(timestamp/1000);
+			nullData.timestamp_unix = Math.ceil(timestamp / 1000);
 
 			var stackPoint = {};
 
-			for(var attr in that.attrList){
+			for (var attr in that.attrList) {
 				stackPoint[that.attrList[attr]] = nullData;
 			}
 
 			return stackPoint;
 		}
 
-    });
+	});
 
-    return NodeModel;
+	return NodeModel;
 });
 
 

--- a/vendor/github.com/labstack/echo/go.mod
+++ b/vendor/github.com/labstack/echo/go.mod
@@ -1,5 +1,7 @@
 module github.com/labstack/echo
 
+go 1.15
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible


### PR DESCRIPTION
* Fix display bug when not enough values return to the latency graph, graph doesn't chart latencies (just total ops).
* Fix display bug where latency values could be displayed twice in the mouse hover legend sometimes.
* Change removal of values from the latency graph to use unix timestamp instead of local time.
* Add support for [microsecond-histograms](https://www.aerospike.com/docs/reference/configuration/?show-removed=1#microsecond-histograms) (5.1+).
* Reformat JS code for readability.
